### PR TITLE
add page type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/gorilla/schema v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/smartystreets/goconvey v1.6.4
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/handlers/feedback.go
+++ b/handlers/feedback.go
@@ -80,7 +80,7 @@ func getFeedback(w http.ResponseWriter, req *http.Request, url, errorType, descr
 	p.ServiceDescription = services[req.URL.Query().Get("service")]
 
 	p.Language = lang
-
+	p.Type = "feedback"
 	p.Metadata.Title = "Feedback"
 	p.Metadata.Description = url
 

--- a/handlers/feedback_test.go
+++ b/handlers/feedback_test.go
@@ -73,6 +73,7 @@ func Test_getFeedback(t *testing.T) {
 				expectedPage.PreviousURL = url
 				expectedPage.Metadata.Description = url
 				expectedPage.ServiceDescription = "ONS developer website"
+				expectedPage.Type = "feedback"
 				expectedJSON, _ := json.Marshal(expectedPage)
 
 				actualJSON := string(mockRenderer.DoCalls()[0].B)


### PR DESCRIPTION
### What

This is one of 3 PRs to fix a bug. The feedback form has been redirecting to a page/template that doesn't exist (/feedback/thanks, "feedback-thanks"). This makes a success message render on the page, redirects will be removed later.
Frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/660
Sixteens: https://github.com/ONSdigital/sixteens/pull/279

### How to review

Pull branches and see that the success message renders on the page: 
<img width="1008" alt="Screenshot 2022-07-11 at 13 04 46" src="https://user-images.githubusercontent.com/16807393/178686820-dd9dfbc1-ec50-4379-afcd-f6f183f45e80.png">

### Who can review

Frontend dev