### PR TITLE
Feature/add search service

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -70,7 +70,7 @@ func CreateGetFeedback(req *http.Request, basePage core.Page, validationErrors [
 			{
 				Input: core.Input{
 					ID:        "specific-page",
-					IsChecked: ff.Type == "A specific page" || ff.URL != "",
+					IsChecked: ff.Type == "A specific page" || (ff.URL != "" && serviceDescription == ""),
 					Label: core.Localisation{
 						LocaleKey: "FeedbackASpecificPage",
 						Plural:    1,
@@ -82,7 +82,12 @@ func CreateGetFeedback(req *http.Request, basePage core.Page, validationErrors [
 					Autocomplete: "url",
 					ID:           "page-url-field",
 					Name:         "url",
-					Value:        ff.URL,
+					Value: func() string {
+						if serviceDescription != "" {
+							return ""
+						}
+						return ff.URL
+					}(),
 					Label: core.Localisation{
 						LocaleKey: "FeedbackWhatEnterURL",
 						Plural:    1,
@@ -108,7 +113,7 @@ func CreateGetFeedback(req *http.Request, basePage core.Page, validationErrors [
 			core.Radio{
 				Input: core.Input{
 					ID:        "new-service",
-					IsChecked: ff.Type == "new-service",
+					IsChecked: true,
 					Label: core.Localisation{
 						Text: helper.Localise("FeedbackWhatOptNewService", lang, 1, serviceDescription),
 					},

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -24,6 +24,7 @@ func CreateGetFeedback(req *http.Request, basePage core.Page, validationErrors [
 	var services = make(map[string]string)
 	services["cmd"] = "customising data by applying filters"
 	services["dev"] = "ONS developer"
+	services["search"] = "search"
 	serviceDescription := services[req.URL.Query().Get("service")]
 
 	p.Language = lang


### PR DESCRIPTION
### What

This adds an extra service option for [search](https://jira.ons.gov.uk/browse/DIS-1104)

A couple assumptions about radio behaviours
- if a service is given, eg `/feedback?service=search`, then that service radio should be the default one checked
- then if this is the case the "specific page" input box should be blank

If this isn't the expected behaviour I can change it to only do it when `search` is given as a service

### How to review

Run the feedback controller
Goto http://localhost:25200/feedback?service=search
Check if extra option is there

**With search service**
<img width="663" alt="image" src="https://github.com/ONSdigital/dp-frontend-feedback-controller/assets/110108574/95f52448-6674-48d2-82df-bc3e22a6aa2a">


**Without search service**
<img width="702" alt="image" src="https://github.com/ONSdigital/dp-frontend-feedback-controller/assets/110108574/dca673bd-37a3-4407-bdb4-d3f49a0458a9">


### Who can review

Frontend